### PR TITLE
Install: fix Arch GUI install + harden against unset env vars

### DIFF
--- a/install
+++ b/install
@@ -1019,6 +1019,17 @@ create_initial_dirs() {
   fi
 }
 
+install_mise_config_symlink() {
+  # mise's `mise use --global` writes to ~/.config/mise/config.toml during
+  # install_packages. Without the symlink already in place, those writes
+  # land in a real file that install_configs later replaces with the symlink,
+  # silently dropping the version pins. Pre-create just this one symlink so
+  # the rest of install_configs can stay in its original spot (after
+  # install_packages), avoiding /etc/* conflicts with not-yet-installed
+  # packages like pacman-contrib.
+  ln -fns "${DOTFILES_PATH}/.config/mise/config.toml" "${XDG_CONFIG_HOME}/mise/config.toml"
+}
+
 install_packages() {
   _info "INSTALL PACKAGES"
 
@@ -2242,13 +2253,14 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
   check_install_config
   ensure_sudo_works
   create_initial_dirs
-  install_configs
+  install_mise_config_symlink
   install_packages
   install_fonts
   install_gui_themes
   install_zsh_plugins
   install_external_scripts
   install_claude_code
+  install_configs
   configure_sudoers_entries
   configure_systemd_services
   configure_system_configs

--- a/install
+++ b/install
@@ -11,7 +11,7 @@ DOTFILES_PATH="$(realpath "$(dirname "${BASH_SOURCE[0]}")")"
 
 # Trust the mise config shipped in this repo so every mise invocation
 # downstream of this script reads it without demanding interactive trust.
-export MISE_TRUSTED_CONFIG_PATHS="${DOTFILES_PATH}/.config/mise/config.toml"
+export MISE_TRUSTED_CONFIG_PATHS="${MISE_TRUSTED_CONFIG_PATHS:+${MISE_TRUSTED_CONFIG_PATHS}:}${DOTFILES_PATH}/.config/mise/config.toml"
 
 # shellcheck disable=SC1091
 . "${DOTFILES_PATH}/bootstrap"
@@ -1721,7 +1721,7 @@ EOF
     echo "${shell_path}" | sudo tee -a /etc/shells 1>/dev/null
   fi
 
-  [ "${SHELL: -3}" != "zsh" ] && sudo chsh -s "${shell_path}" "${USER}"
+  [[ "${SHELL:-}" != *zsh ]] && sudo chsh -s "${shell_path}" "${USER:-$(whoami)}"
 
   # shellcheck disable=SC1091
   . "${XDG_CONFIG_HOME}/zsh/.zprofile" 1>/dev/null


### PR DESCRIPTION
## Summary

Two fixes for the install script, both surfaced by full end-to-end VM validation:

- **`install_configs` early move broke Arch GUI install** (regresses 6ca666e). The Ubuntu-only test for that change missed two Arch-specific failures: `/etc/conf.d/` doesn't exist before `pacman-contrib` is installed, and even with the parent dir created pacman refuses to install `pacman-contrib` because the dotfiles symlink already owns the file. Restore `install_configs` to its original spot (after `install_claude_code`) and replace the early call with a focused `install_mise_config_symlink` that handles only the one user-side file 6ca666e was actually trying to protect.
- **Harden against unset/inherited env vars.** Unaddressed review comments from #22 — `MISE_TRUSTED_CONFIG_PATHS` is now appended (not clobbered), and `\${SHELL}` / `\${USER}` no longer trip nounset on the minimal-Docker path the README documents.

## Test plan

- [x] Lima x86_64 Arch VM, GUI_LINUX=1 end-to-end: 807 pacman + 17 AUR packages installed, mise tools (node, bun, python, go, rust, zig) end up in the symlinked `~/.config/mise/config.toml`, `/etc/conf.d/pacman-contrib` resolves to the dotfiles, `completed_message` reached
- [x] Verified `install_configs` no longer aborts on the missing `/etc/conf.d/` parent and pacman no longer fails on the file conflict

🤖 Generated with [Claude Code](https://claude.com/claude-code)