### PR TITLE
Simplify flexoki-dark ghostty + tmux theme files

### DIFF
--- a/_themes/flexoki-dark/ghostty
+++ b/_themes/flexoki-dark/ghostty
@@ -1,28 +1,2 @@
 # Flexoki Dark palette
-background = 100F0F
-foreground = CECDC3
-
-# Normal colors (0-7)
-palette = 0=#1C1B1A
-palette = 1=#AF3029
-palette = 2=#66800B
-palette = 3=#AD8301
-palette = 4=#205EA6
-palette = 5=#A02F6F
-palette = 6=#24837B
-palette = 7=#CECDC3
-
-# Bright colors (8-15)
-palette = 8=#403E3C
-palette = 9=#D14D41
-palette = 10=#879A39
-palette = 11=#D0A215
-palette = 12=#4385BE
-palette = 13=#CE5D97
-palette = 14=#3AA99F
-palette = 15=#FFFCF0
-
-cursor-color = CECDC3
-cursor-text = 100F0F
-selection-background = 343331
-selection-foreground = CECDC3
+theme = Flexoki Dark

--- a/_themes/flexoki-dark/tmux.conf
+++ b/_themes/flexoki-dark/tmux.conf
@@ -1,8 +1,12 @@
-set -g mode-style "fg=#4385BE,bg=#282726"
-
-set -g pane-border-style "fg=#403E3C"
-set -g pane-active-border-style "fg=#4385BE"
-
-set -g status-style "fg=#4385BE,bg=#100F0F"
-set -g window-status-style "fg=#878580,bg=#100F0F"
-set -g window-status-current-style "fg=#4385BE,bg=#100F0F"
+# Theme
+set -g status-style "bg=default,fg=default"
+set -g status-left "#[fg=black,bg=blue,bold] #S #[bg=default] "
+set -g status-right "#[fg=blue]#{?client_prefix,PREFIX ,}#{?window_zoomed_flag,ZOOM ,}#[fg=brightblack]#h "
+set -g window-status-format "#[fg=brightblack] #I:#W "
+set -g window-status-current-format "#[fg=blue,bold] #I:#W "
+set -g pane-border-style "fg=brightblack"
+set -g pane-active-border-style "fg=blue"
+set -g message-style "bg=default,fg=blue"
+set -g message-command-style "bg=default,fg=blue"
+set -g mode-style "bg=blue,fg=black"
+setw -g clock-mode-colour blue


### PR DESCRIPTION
## Summary

- **ghostty**: drop the hand-maintained 25-line palette in favor of the built-in `theme = Flexoki Dark` shipped with ghostty
- **tmux**: switch from hardcoded hex colors to terminal-defined colors (default/blue/black/brightblack) and add status-left/right/format lines

## Test plan

- [ ] Reload ghostty and confirm colors match Flexoki Dark
- [ ] Reload tmux and confirm status bar renders with the new layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)