### PR TITLE
Fix flexoki-dark tmux contrast: blue→brightblue, brightblack→white

### DIFF
--- a/_themes/flexoki-dark/tmux.conf
+++ b/_themes/flexoki-dark/tmux.conf
@@ -1,12 +1,12 @@
 # Theme
 set -g status-style "bg=default,fg=default"
-set -g status-left "#[fg=black,bg=blue,bold] #S #[bg=default] "
-set -g status-right "#[fg=blue]#{?client_prefix,PREFIX ,}#{?window_zoomed_flag,ZOOM ,}#[fg=brightblack]#h "
-set -g window-status-format "#[fg=brightblack] #I:#W "
-set -g window-status-current-format "#[fg=blue,bold] #I:#W "
+set -g status-left "#[fg=black,bg=brightblue,bold] #S #[bg=default] "
+set -g status-right "#[fg=brightblue]#{?client_prefix,PREFIX ,}#{?window_zoomed_flag,ZOOM ,}#[fg=white]#h "
+set -g window-status-format "#[fg=white] #I:#W "
+set -g window-status-current-format "#[fg=brightblue,bold] #I:#W "
 set -g pane-border-style "fg=brightblack"
-set -g pane-active-border-style "fg=blue"
-set -g message-style "bg=default,fg=blue"
-set -g message-command-style "bg=default,fg=blue"
-set -g mode-style "bg=blue,fg=black"
-setw -g clock-mode-colour blue
+set -g pane-active-border-style "fg=brightblue"
+set -g message-style "bg=default,fg=brightblue"
+set -g message-command-style "bg=default,fg=brightblue"
+set -g mode-style "bg=brightblue,fg=black"
+setw -g clock-mode-colour brightblue


### PR DESCRIPTION
## Summary
- PR #27 swapped hardcoded hex for named tmux colors but picked the wrong indices
- Original used `#4385BE` (brightblue, color 12) and `#878580` (white/base-500), not `blue` (#205EA6) and `brightblack` (#403E3C)
- Restores palette vibrancy and fixes ~1.8:1 contrast on inactive window names + hostname

## Test plan
- [ ] Reload tmux config and confirm accent color matches pre-#27 appearance
- [ ] Verify inactive window names and hostname are readable against default background