### PR TITLE
Install Flexoki Dark GTK theme via Colloid fork

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -64,8 +64,8 @@ Pi is installed via `MISE_LANGUAGES` with the `npm:` backend: `npm:@mariozechner
 Nickjj's theme-switching architecture, retained and extended. The main config for each themed tool (ghostty, tmux, nvim, btop, fzf, niri, waybar, mako, walker, swaylock, zathura, gtk) references an externally-symlinked theme file. `set_theme()` (install:2010) relinks those files from `_themes/<active>/<file>` to their runtime paths; `dot-theme-set` (`.local/bin/dot-theme-set`) picks which active theme to use.
 
 **Flexoki Dark**:
-Default active theme in Phase 1. Authored as `_themes/flexoki-dark/` by copying `_themes/tokyonight-moon/` and translating palette values to the Flexoki palette (`#100F0F` bg, `#CECDC3` fg, etc. — full palette sourced from `ivn-term/config/ghostty/config`).
-_Avoid_: Flexoki, flexoki (without the mode suffix — we may add a light variant in Phase 2).
+Default active theme in Phase 1. Authored as `_themes/flexoki-dark/` by copying `_themes/tokyonight-moon/` and translating palette values to the Flexoki palette (`#100F0F` bg, `#CECDC3` fg, etc. — full palette sourced from `ivn-term/config/ghostty/config`). GTK portion of the theme is built from `imrellx/Colloid-gtk-theme` (our fork of `vinceliuice/Colloid-gtk-theme`) using a custom `_color-palette-flexoki.scss` + `--tweaks flexoki` scheme; the built theme is hosted as a release asset on the fork and pulled via `install_gui_themes()` like the other two themes.
+_Avoid_: Flexoki, flexoki (without the mode suffix — we may add a light variant later).
 
 ## Relationships
 

--- a/install
+++ b/install
@@ -1264,6 +1264,11 @@ install_gui_themes() {
     "https://github.com/user-attachments/files/26270135/Gruvbox-BL-LB-dark-Medium.zip" \
     "Gruvbox-BL-LB-Dark-Medium"
 
+  _theme_download \
+    "flexoki-dark" \
+    "https://github.com/imrellx/Colloid-gtk-theme/releases/download/flexoki-v1/flexoki-dark-colloid.zip" \
+    "Colloid-Dark-Flexoki"
+
   printf "\nThey were installed to '%s'\n" "${XDG_DATA_HOME}/themes/"
 }
 


### PR DESCRIPTION
## Summary

Closes the Phase 1 loose end on [PRD 0001 story 31](docs/prd/0001-phase-1-re-origin.md) — Flexoki GTK theme — by pulling a pre-built Flexoki variant of Colloid from our own fork.

## What landed

- **`install`**: new `_theme_download` call in `install_gui_themes()` pulls `Colloid-Dark-Flexoki` from `imrellx/Colloid-gtk-theme` release `flexoki-v1` and installs it as `~/.local/share/themes/flexoki-dark/`. Same shape as the existing `tokyonight-moon` and `gruvbox-dark-medium` calls.
- **`CONTEXT.md`**: Flexoki Dark language block notes the Colloid fork + release-asset distribution.
- **`_themes/flexoki-dark/gtk.ini`**: already pointed at `gtk-theme-name = flexoki-dark`; no change needed. `set_theme()` now finds a real theme directory at that path.

## How the fork side works

`imrellx/Colloid-gtk-theme` is a fork of `vinceliuice/Colloid-gtk-theme` with one extra palette and minimal scaffolding, matching Colloid's existing first-class palette-injection pattern (nord, dracula, gruvbox, everforest, catppuccin):

- `src/sass/_color-palette-flexoki.scss` — 75 lines. Full Flexoki base ramp (15 tones) + 8 accents (red, pink, purple, blue, teal, green, yellow, orange). Purple/orange from Flexoki's extended palette since the ANSI-16 subset only covers 6 hues. Source: https://stephango.com/flexoki.
- `install.sh` — 3 edits (help text, `tweaks` parser case, `color_schemes` case) + 1 array entry. Matches the existing scheme pattern exactly.
- `src/main/labwc/themerc-Dark-Flexoki` and `src/main/plank/theme-Dark-Flexoki/dock.theme` — color stubs needed to satisfy Colloid's copy steps for window managers we don't use.
- `src/assets/gtk-2.0/assets-Dark-Flexoki/` — 38 PNG stand-ins from Dark-Gruvbox. GTK-2 is legacy; the small-pixel widgets are close enough that the Gruvbox tone is acceptable until someone renders proper Flexoki SVGs.

Build pipeline: `docker run --rm -v \$PWD:/work ubuntu:24.04 bash -c '... sassc ... && ./install.sh --tweaks flexoki --color dark --dest /work/build-out'`. Output zipped and attached to release `flexoki-v1`.

## Release asset URL

https://github.com/imrellx/Colloid-gtk-theme/releases/download/flexoki-v1/flexoki-dark-colloid.zip (~469 KB, double-wrapped per `_theme_download` expectations).

## Not upstreamed (yet)

Kept local for now. If Flexoki lands upstream organically (we or anyone else files a PR that gets merged), a future dotfiles PR just swaps the release URL to pull from `vinceliuice/Colloid-gtk-theme` releases and we drop the fork.

## Test plan

- [ ] Fresh install on an Arch-with-GUI VM: `install_gui_themes` downloads + unpacks the zip to `~/.local/share/themes/flexoki-dark/`, `set_theme` symlinks gtk-4.0 assets/css into `~/.config/gtk-4.0/` and runs `gsettings set`, GTK 4 apps render with Flexoki colors
- [ ] Re-running `install`: `_theme_download` skips (theme already installed)
- [ ] Open a GTK 4 app (Nautilus, ptyxis, gnome-calculator, etc.) and confirm Flexoki accent colours render
- [ ] Check `~/.config/gtk-3.0/settings.ini` and `~/.config/gtk-4.0/settings.ini` point at `gtk-theme-name = flexoki-dark`

🤖 Generated with [Claude Code](https://claude.com/claude-code)