### PR TITLE
Make fzf + zsh configs safe to source under errexit in non-tty

### DIFF
--- a/.config/fzf/config.sh
+++ b/.config/fzf/config.sh
@@ -3,4 +3,6 @@ export FZF_DEFAULT_OPTS="--ansi --info=inline-right --layout=reverse --border=no
 export FZF_CTRL_T_OPTS="--height=100% --preview='bat --color=always {}'"
 
 # shellcheck disable=SC1091
-. "${XDG_CONFIG_HOME}/fzf/theme.sh"
+if [ -f "${XDG_CONFIG_HOME}/fzf/theme.sh" ]; then
+  . "${XDG_CONFIG_HOME}/fzf/theme.sh"
+fi

--- a/.config/zsh/.zprofile
+++ b/.config/zsh/.zprofile
@@ -9,7 +9,8 @@
 . "${XDG_CONFIG_HOME:-"${HOME}/.config"}/zsh/.envs"
 
 # Allows gpg-agent to prompt for passphrase (useful for signing commits).
-GPG_TTY="$(tty)"
+# `tty` exits non-zero in non-tty contexts (e.g. sourced by the installer); tolerate that.
+GPG_TTY="$(tty 2>/dev/null || true)"
 export GPG_TTY
 
 # Add colors to less and man.


### PR DESCRIPTION
## Summary

Two config files fail when sourced by the installer (non-interactive bash, piped stdin, `set -o errexit`):

- `.config/fzf/config.sh` unconditionally sourced `theme.sh`, which is a symlink created later by `set_theme()`. On fresh install, `configure_shell()` sources this file before the symlink exists, errexit kills the installer.
- `.config/zsh/.zprofile` called `tty` unconditionally, which exits 1 when stdin is a pipe (installer context). Errexit kills the installer.

Both fixes are robustness-only and don't change interactive behaviour.

## Test plan
- [x] Fresh Arch Lima VM (x86_64, virtio-gpu); single-line `bash <(curl ... bootstrap)`; option 2 (GUI); ran to completion, exit=0
- [ ] Second fresh VM pass against this branch to confirm reproducibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)