### PR TITLE
feat(install): dot-hw-* family + dot-update-* primitives (2a/2)

### DIFF
--- a/.local/bin/dot-hw-asus-rog
+++ b/.local/bin/dot-hw-asus-rog
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# lifted from omarchy/bin/omarchy-hw-asus-rog
+
+# Detect whether the computer is an Asus ROG machine.
+
+[[ $(cat /sys/class/dmi/id/sys_vendor 2>/dev/null) == "ASUSTeK COMPUTER INC." ]] &&
+  grep -q "ROG" /sys/class/dmi/id/product_family 2>/dev/null

--- a/.local/bin/dot-hw-dell-xps-oled
+++ b/.local/bin/dot-hw-dell-xps-oled
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# lifted from omarchy/bin/omarchy-hw-dell-xps-oled
+
+# Match Dell XPS systems with LG OLED panel on Intel Panther Lake (Xe3) GPU.
+
+dot-hw-match "XPS" &&
+  dot-hw-intel-ptl &&
+  test "$(od -An -tx1 -j8 -N2 /sys/class/drm/card*-eDP-*/edid 2>/dev/null | tr -d ' \n')" = "30e4"

--- a/.local/bin/dot-hw-framework16
+++ b/.local/bin/dot-hw-framework16
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# lifted from omarchy/bin/omarchy-hw-framework16
+
+# Detect whether the computer is a Framework Laptop 16.
+
+[[ $(cat /sys/class/dmi/id/sys_vendor 2>/dev/null) == "Framework" ]] &&
+  dot-hw-match "Laptop 16"

--- a/.local/bin/dot-hw-intel
+++ b/.local/bin/dot-hw-intel
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# lifted from omarchy/bin/omarchy-hw-intel
+
+# Detect whether the computer has an Intel CPU.
+
+[[ $(grep -m1 "vendor_id" /proc/cpuinfo 2>/dev/null | cut -d: -f2 | tr -d ' ') == "GenuineIntel" ]]

--- a/.local/bin/dot-hw-intel-ptl
+++ b/.local/bin/dot-hw-intel-ptl
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# lifted from omarchy/bin/omarchy-hw-intel-ptl
+
+# Detect whether the computer has an Intel Panther Lake GPU.
+
+lspci | grep -iE 'vga|3d|display' | grep -qi 'panther lake'

--- a/.local/bin/dot-hw-match
+++ b/.local/bin/dot-hw-match
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# lifted from omarchy/bin/omarchy-hw-match
+
+# Match against the computer's DMI product name (case-insensitive).
+# Usage: dot-hw-match "XPS"
+
+grep -qi "$1" /sys/class/dmi/id/product_name 2>/dev/null

--- a/.local/bin/dot-hw-surface
+++ b/.local/bin/dot-hw-surface
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# lifted from omarchy/bin/omarchy-hw-surface
+
+# Detect whether the computer is a Microsoft Surface device.
+
+[[ $(cat /sys/class/dmi/id/sys_vendor 2>/dev/null) == "Microsoft Corporation" ]] &&
+  dot-hw-match "Surface"

--- a/.local/bin/dot-hw-vulkan
+++ b/.local/bin/dot-hw-vulkan
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# lifted from omarchy/bin/omarchy-hw-vulkan
+
+# Detect whether Vulkan is available.
+
+[[ -d /usr/share/vulkan/icd.d ]] &&
+  find /usr/share/vulkan/icd.d -maxdepth 1 -name "*.json" -print -quit | grep -q .

--- a/.local/bin/dot-update-aur-pkgs
+++ b/.local/bin/dot-update-aur-pkgs
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# lifted from omarchy/bin/omarchy-update-aur-pkgs
+
+# Update AUR packages if any are installed
+if pacman -Qem >/dev/null; then
+  if dot-pkg-aur-accessible; then
+    echo -e "\e[32m\nUpdate AUR packages\e[0m"
+    yay -Sua --noconfirm --cleanafter --ignore gcc14,gcc14-libs
+    echo
+  else
+    echo -e "\e[31m\nAUR is unavailable (so skipping updates)\e[0m"
+    echo
+  fi
+fi

--- a/.local/bin/dot-update-firmware
+++ b/.local/bin/dot-update-firmware
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# lifted from omarchy/bin/omarchy-update-firmware
+
+# Update system firmware using fwupd. Ensures the fwupd EFI binary is installed
+# in the ESP so UEFI capsule updates work with the Limine bootloader.
+
+set -e
+echo -e "\e[32mUpdate Firmware\e[0m"
+
+# dropped: `omarchy-cmd-missing fwupdmgr` guard (omarchy helper skipped per PRD-0003).
+# `dot-pkg-add` is idempotent on its own (via dot-pkg-missing + pacman -Q), so the
+# outer guard is redundant.
+dot-pkg-add fwupd
+
+if [[ -d /sys/firmware/efi ]] && [[ -f /usr/lib/fwupd/efi/fwupdx64.efi ]]; then
+  sudo install -D /usr/lib/fwupd/efi/fwupdx64.efi /boot/EFI/arch/fwupdx64.efi
+fi
+
+fwupdmgr refresh --force
+sudo fwupdmgr update

--- a/.local/bin/dot-update-keyring
+++ b/.local/bin/dot-update-keyring
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# lifted from omarchy/bin/omarchy-update-keyring
+
+# Refresh archlinux-keyring so pacman can verify the latest maintainer signatures.
+# dropped: omarchy-keyring setup block (AUR package + omarchy signing key
+# `40DFB630FF42BCFFB047046CF0134EE680CAC571`). Not applicable outside the omarchy
+# distribution — we don't pull from omarchy's AUR mirror or package repo.
+
+echo -e "\e[32m\nUpdate Arch signing keys\e[0m"
+sudo pacman -Sy --noconfirm archlinux-keyring >/dev/null

--- a/.local/bin/dot-update-orphan-pkgs
+++ b/.local/bin/dot-update-orphan-pkgs
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# lifted from omarchy/bin/omarchy-update-orphan-pkgs
+
+# Remove orphaned packages (installed as deps, no longer required by anything).
+
+orphans=$(pacman -Qtdq || true)
+if [[ -n $orphans ]]; then
+  echo -e "\e[32m\nRemove orphan system packages\e[0m"
+  for pkg in $orphans; do
+    sudo pacman -Rs --noconfirm "$pkg" || true
+  done
+  echo
+fi

--- a/.local/bin/dot-update-system-pkgs
+++ b/.local/bin/dot-update-system-pkgs
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# lifted from omarchy/bin/omarchy-update-system-pkgs
+
+# Upgrade every pacman-managed package on the system (full sync).
+
+set -e
+
+echo -e "\e[32m\nUpdate system packages\e[0m"
+sudo pacman -Syyu --noconfirm

--- a/.local/bin/dot-update-time
+++ b/.local/bin/dot-update-time
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# lifted from omarchy/bin/omarchy-update-time
+
+# Restart systemd-timesyncd so the system clock resynchronises from NTP.
+
+echo "Updating time..."
+sudo systemctl restart systemd-timesyncd

--- a/_install/default/packages/arch
+++ b/_install/default/packages/arch
@@ -15,6 +15,7 @@ export DEFAULT_PACKAGES_PACMAN=(
   "fd"
   "ffmpeg"
   "fontconfig"
+  "fwupd"
   "fzf"
   "git"
   "git-delta"


### PR DESCRIPTION
## Summary

- Slice 2 of Phase 2a ([PRD-0003](../blob/main/docs/prd/0003-omarchy-scripts-import.md)). Imports 14 compositor-neutral scripts from omarchy/bin under the `dot-*` prefix per [ADR-0003](../blob/main/docs/adr/0003-rename-omarchy-scripts-to-dot-prefix.md).
- Hardware family (8): `dot-hw-match`, `dot-hw-asus-rog`, `dot-hw-framework16`, `dot-hw-surface`, `dot-hw-dell-xps-oled`, `dot-hw-intel`, `dot-hw-intel-ptl`, `dot-hw-vulkan`.
- Update primitives (6): `dot-update-firmware`, `dot-update-keyring`, `dot-update-system-pkgs`, `dot-update-aur-pkgs`, `dot-update-orphan-pkgs`, `dot-update-time`.

## Context

Work was originally implemented on `ralph/2a-4-restart-family` (commit `95a73b4`) but never pushed. Recovered via cherry-pick onto a fresh branch from current `main`. Closes #41.

## Test plan

- [ ] `.local/bin/dot-hw-intel` returns 0 on Intel host
- [ ] `.local/bin/dot-hw-vulkan` returns 0 when a Vulkan ICD is installed
- [ ] `.local/bin/dot-update-keyring` refreshes `archlinux-keyring` without error
- [ ] Install script still runs end-to-end on Arch