### PR TITLE
feat(install): dot-restart-* compositor-neutral family (2a/4)

### DIFF
--- a/.local/bin/dot-restart-app
+++ b/.local/bin/dot-restart-app
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# lifted from omarchy/bin/omarchy-restart-app
+
+# Restart an application by killing it and relaunching via uwsm.
+# Usage: dot-restart-app <application-name> [application-args...]
+
+pkill -x "$1"
+setsid uwsm-app -- "$@" >/dev/null 2>&1 &

--- a/.local/bin/dot-restart-bluetooth
+++ b/.local/bin/dot-restart-bluetooth
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# lifted from omarchy/bin/omarchy-restart-bluetooth
+
+# Unblock and restart the bluetooth service.
+
+echo -e "Unblocking bluetooth...\n"
+rfkill unblock bluetooth
+rfkill list bluetooth

--- a/.local/bin/dot-restart-btop
+++ b/.local/bin/dot-restart-btop
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# lifted from omarchy/bin/omarchy-restart-btop
+
+# Reload btop configuration (used by the Omarchy theme switching).
+
+pkill -SIGUSR2 btop

--- a/.local/bin/dot-restart-mako
+++ b/.local/bin/dot-restart-mako
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# lifted from omarchy/bin/omarchy-restart-mako
+
+# Reload mako configuration (used by the Omarchy theme switching).
+
+makoctl reload

--- a/.local/bin/dot-restart-opencode
+++ b/.local/bin/dot-restart-opencode
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# lifted from omarchy/bin/omarchy-restart-opencode
+
+# Reload opencode configuration (used by the Omarchy theme switching).
+
+if pgrep -x opencode >/dev/null; then
+  killall -SIGUSR2 opencode
+fi

--- a/.local/bin/dot-restart-pipewire
+++ b/.local/bin/dot-restart-pipewire
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# lifted from omarchy/bin/omarchy-restart-pipewire
+
+# Restart the PipeWire audio service to fix audio issues or apply new configuration.
+
+echo -e "Restarting pipewire audio service...\n"
+systemctl --user restart pipewire.service

--- a/.local/bin/dot-restart-swayosd
+++ b/.local/bin/dot-restart-swayosd
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# lifted from omarchy/bin/omarchy-restart-swayosd
+
+dot-restart-app swayosd-server

--- a/.local/bin/dot-restart-terminal
+++ b/.local/bin/dot-restart-terminal
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# lifted from omarchy/bin/omarchy-restart-terminal
+
+if [[ -f ~/.config/alacritty/alacritty.toml ]]; then
+  touch ~/.config/alacritty/alacritty.toml
+fi
+
+if pgrep -x kitty >/dev/null; then
+  killall -SIGUSR1 kitty >/dev/null
+fi
+
+if pgrep -x ghostty >/dev/null; then
+  killall -SIGUSR2 ghostty
+fi

--- a/.local/bin/dot-restart-tmux
+++ b/.local/bin/dot-restart-tmux
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# lifted from omarchy/bin/omarchy-restart-tmux
+
+# Restart tmux if running with the latest configuration
+
+if pgrep -x tmux; then
+  tmux source-file ~/.config/tmux/tmux.conf
+fi

--- a/.local/bin/dot-restart-trackpad
+++ b/.local/bin/dot-restart-trackpad
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# lifted from omarchy/bin/omarchy-restart-trackpad
+
+# Reset the trackpad by unbinding and rebinding its driver.
+# Covers both driver paths:
+#   - i2c_hid_acpi (DesignWare I2C, e.g. XPS 14/16 Synaptics trackpad)
+#   - intel_quicki2c (THC Touch Host Controller)
+
+# Try i2c_hid_acpi path (DesignWare I2C trackpads)
+for dev in /sys/bus/i2c/drivers/i2c_hid_acpi/i2c-*; do
+  [ -e "$dev" ] || continue
+  I2C_DEVICE=$(basename "$dev")
+  echo "Resetting $I2C_DEVICE via i2c_hid_acpi unbind/rebind..."
+  echo "$I2C_DEVICE" | sudo tee /sys/bus/i2c/drivers/i2c_hid_acpi/unbind >/dev/null
+  sleep 1
+  echo "$I2C_DEVICE" | sudo tee /sys/bus/i2c/drivers/i2c_hid_acpi/bind >/dev/null
+  echo "Done"
+done
+
+# Also try THC path
+if lsmod | grep -q intel_quicki2c; then
+  echo "Reloading intel_quicki2c..."
+  sudo modprobe -r intel_quicki2c && sudo modprobe intel_quicki2c
+fi

--- a/.local/bin/dot-restart-walker
+++ b/.local/bin/dot-restart-walker
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# lifted from omarchy/bin/omarchy-restart-walker
+
+restart_services() {
+  if systemctl --user is-enabled elephant.service &>/dev/null; then
+    systemctl --user restart elephant.service
+  fi
+
+  if systemctl --user is-enabled app-walker@autostart.service &>/dev/null; then
+    systemctl --user restart app-walker@autostart.service
+  else
+    echo -e "\e[31mUnable to restart Walker -- RESTART MANUALLY\e[0m"
+  fi
+}
+
+if ((EUID == 0)); then
+  SCRIPT_OWNER=$(stat -c '%U' "$0")
+  USER_UID=$(id -u "$SCRIPT_OWNER")
+  systemd-run --uid="$SCRIPT_OWNER" --setenv=XDG_RUNTIME_DIR="/run/user/$USER_UID" \
+    bash -c "$(declare -f restart_services); restart_services"
+else
+  restart_services
+fi

--- a/.local/bin/dot-restart-waybar
+++ b/.local/bin/dot-restart-waybar
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# lifted from omarchy/bin/omarchy-restart-waybar
+
+dot-restart-app waybar

--- a/.local/bin/dot-restart-wifi
+++ b/.local/bin/dot-restart-wifi
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# lifted from omarchy/bin/omarchy-restart-wifi
+
+# Unblock and restart the Wi-Fi service.
+
+echo -e "Unblocking wifi...\n"
+rfkill unblock wifi
+rfkill list wifi

--- a/.local/bin/dot-restart-xcompose
+++ b/.local/bin/dot-restart-xcompose
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# lifted from omarchy/bin/omarchy-restart-xcompose
+
+# Restart the XCompose input method service (fcitx5) to apply new compose key settings.
+
+dot-restart-app fcitx5 --disable notificationitem


### PR DESCRIPTION
Slice 4 of Phase 2a ([PRD-0003](../blob/main/docs/prd/0003-omarchy-scripts-import.md)). Cherry-picked from cec452b. Closes #38.