### PR TITLE
feat(install): dot-launch-* compositor-neutral family (2a/6)

### DIFF
--- a/.local/bin/dot-launch-browser
+++ b/.local/bin/dot-launch-browser
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# lifted from omarchy/bin/omarchy-launch-browser
+
+# Launch the default browser as determined by xdg-settings.
+# Automatically converts --private into the correct flag for the given browser.
+
+default_browser=$(xdg-settings get default-web-browser)
+browser_exec=$(sed -n 's/^Exec=\([^ ]*\).*/\1/p' {~/.local,~/.nix-profile,/usr}/share/applications/"$default_browser" 2>/dev/null | head -1)
+
+if $browser_exec --help | grep -q MOZ_LOG; then
+  private_flag="--private-window"
+elif [[ $browser_exec =~ edge ]]; then
+  private_flag="--inprivate"
+else
+  private_flag="--incognito"
+fi
+
+exec setsid uwsm-app -- "$browser_exec" "${@/--private/$private_flag}"

--- a/.local/bin/dot-launch-editor
+++ b/.local/bin/dot-launch-editor
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# lifted from omarchy/bin/omarchy-launch-editor
+
+# Launch the default editor as determined by $EDITOR (set via ~/.config/uwsm/default) (or nvim if missing).
+# Starts suitable editors in a terminal window and otherwise as a regular application.
+
+command -v "$EDITOR" &>/dev/null || EDITOR=nvim
+
+case "$EDITOR" in
+nvim | vim | nano | micro | hx | helix | fresh)
+  exec dot-launch-tui "$EDITOR" "$@"
+  ;;
+*)
+  exec setsid uwsm-app -- "$EDITOR" "$@"
+  ;;
+esac

--- a/.local/bin/dot-launch-floating-terminal-with-presentation
+++ b/.local/bin/dot-launch-floating-terminal-with-presentation
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# lifted from omarchy/bin/omarchy-launch-floating-terminal-with-presentation
+
+# Launch a floating terminal and execute the command passed in.
+# Used by actions such as Update System.
+
+cmd="$*"
+exec setsid uwsm-app -- xdg-terminal-exec --app-id=org.omarchy.terminal --title=Omarchy -e bash -c "$cmd"

--- a/.local/bin/dot-launch-walker
+++ b/.local/bin/dot-launch-walker
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# lifted from omarchy/bin/omarchy-launch-walker
+
+# Launch the Walker application launcher while ensuring that it's data provider (called elephant) is running first.
+
+# Ensure elephant is running before launching walker
+if ! pgrep -x elephant >/dev/null; then
+  setsid uwsm-app -- elephant &
+fi
+
+# Ensure walker service is running
+if ! pgrep -f "walker --gapplication-service" >/dev/null; then
+  setsid uwsm-app -- env GSK_RENDERER=cairo walker --gapplication-service &
+fi
+
+exec walker --width 644 --maxheight 300 --minheight 300 "$@"

--- a/.local/bin/dot-launch-webapp
+++ b/.local/bin/dot-launch-webapp
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# lifted from omarchy/bin/omarchy-launch-webapp
+
+# Launch the passed in URL as a web app in the default browser (or chromium if the default doesn't support --app).
+
+browser=$(xdg-settings get default-web-browser)
+
+case $browser in
+google-chrome* | brave* | microsoft-edge* | opera* | vivaldi* | helium*) ;;
+*) browser="chromium.desktop" ;;
+esac
+
+exec setsid uwsm-app -- "$(sed -n 's/^Exec=\([^ ]*\).*/\1/p' {~/.local,~/.nix-profile,/usr}/share/applications/"$browser" 2>/dev/null | head -1)" --app="$1" "${@:2}"


### PR DESCRIPTION
Slice 6 of Phase 2a ([PRD-0003](../blob/main/docs/prd/0003-omarchy-scripts-import.md)). Cherry-picked from 3b7037b (originally on ralph/2a-6-launch-family, never pushed). Closes #39.