### PR TITLE
fix(nvim): use npx to run yarn for markdown-preview build

### DIFF
--- a/.config/nvim/lua/plugins/markdown.lua
+++ b/.config/nvim/lua/plugins/markdown.lua
@@ -9,7 +9,7 @@ return {
       vim.g.mkdp_auto_close = false
       vim.g.mkdp_markdown_css = markdown_preview_css_path
     end,
-    build = "cd app && yarn install",
+    build = "cd app && npx --yes yarn install",
   },
   {
     "stevearc/conform.nvim",


### PR DESCRIPTION
The build hook for `iamcco/markdown-preview.nvim` at `.config/nvim/lua/plugins/markdown.lua:12` installs a small Node app under `app/` so the plugin can render markdown in a browser.

We removed yarn in Phase 1, so this hook silently fails on a fresh install. Switch to the upstream-endorsed `npx --yes yarn install` form: still runs yarn under the hood, no global yarn required, works with the npm we already have.