### PR TITLE
fix(install): set color-scheme=prefer-dark in set_theme

### DIFF
--- a/install
+++ b/install
@@ -1978,6 +1978,7 @@ set_theme() {
       # Even after symlinking settings.ini, gsettings still needs to run to
       # switch the active theme so it takes effect.
       gsettings set org.gnome.desktop.interface gtk-theme "${theme}"
+      gsettings set org.gnome.desktop.interface color-scheme "prefer-dark"
     fi
 
     [ -n "${switch_wallpaper}" ] && "${DOTFILES_PATH}/.local/bin/dot-theme-set-bg"


### PR DESCRIPTION
## Summary
- Modern apps (libadwaita, Chromium/Electron's `prefers-color-scheme`, xdg-desktop-portal consumers) read `org.freedesktop.appearance color-scheme` — not `gtk-theme` — to decide dark vs. light.
- Without it set, apps render in light mode even though the GTK theme and `settings.ini` are already dark (e.g. `flexoki-dark`).
- `set_theme` already syncs `gtk-theme` via gsettings; this commit applies `color-scheme=prefer-dark` right next to it. All current `_themes/` entries are dark, so unconditional `prefer-dark` is safe.

## Test plan
- [x] `gsettings get org.gnome.desktop.interface color-scheme` → `'prefer-dark'` after running `dot-theme-set` on a dark theme
- [ ] Restart an Electron app (e.g. VS Code) and confirm it picks up dark mode
- [ ] Switch themes via `dot-theme-set` and confirm color-scheme remains `prefer-dark`

🤖 Generated with [Claude Code](https://claude.com/claude-code)